### PR TITLE
feat: PERCEPTION-2797: do not turn plane validation when docking

### DIFF
--- a/apriltags_ros/include/apriltags_ros/apriltag_detector.h
+++ b/apriltags_ros/include/apriltags_ros/apriltag_detector.h
@@ -92,6 +92,7 @@ class AprilTagDetector{
   float plane_inlier_threshold_;
   float plane_angle_threshold_;
   bool publish_plane_cloud_;
+  bool depth_plane_validation_for_docking_;
 
   std::map<int,std::shared_ptr<DetectionPosesQueueWrapper> > tracked_april_tags_with_valid_pose_;
   std::map<int,std::shared_ptr<DetectionPosesQueueWrapper> > all_tracked_april_tags_;

--- a/apriltags_ros/src/apriltag_detector.cpp
+++ b/apriltags_ros/src/apriltag_detector.cpp
@@ -293,7 +293,7 @@ void AprilTagDetector::imageCb(const sensor_msgs::PointCloud2ConstPtr& cloud,
       bool validPose = true;
 
       // The maximum allowed angle delta for each axis
-      if ((diffRoll > plane_angle_threshold_) || (diffPitch > plane_angle_threshold_))
+      if (number_of_frames_to_capture_ == 1 && (diffRoll > plane_angle_threshold_) || (diffPitch > plane_angle_threshold_))
       {
         ROS_DEBUG_THROTTLE(5.0, "April tag and plane poses do not match!");
         ROS_DEBUG_THROTTLE(5.0, "April angle: %f, %f", aprilTagRoll, aprilTagPitch);

--- a/apriltags_ros/src/apriltag_detector.cpp
+++ b/apriltags_ros/src/apriltag_detector.cpp
@@ -293,6 +293,10 @@ void AprilTagDetector::imageCb(const sensor_msgs::PointCloud2ConstPtr& cloud,
       bool validPose = true;
 
       // The maximum allowed angle delta for each axis
+      // using number_of_frames_to_capture_ == 1 comparison below is a quick hack to accelerate docking
+      // that check ensures that we only validate depth plane for localization
+      // that check means that we skip plane validation for docking (which requires more than 1 april tag detection)
+      // full version will not use this hack
       if (number_of_frames_to_capture_ == 1 && (diffRoll > plane_angle_threshold_) || (diffPitch > plane_angle_threshold_))
       {
         ROS_DEBUG_THROTTLE(5.0, "April tag and plane poses do not match!");

--- a/apriltags_ros/src/apriltag_detector.cpp
+++ b/apriltags_ros/src/apriltag_detector.cpp
@@ -96,6 +96,7 @@ AprilTagDetector::AprilTagDetector(ros::NodeHandle& nh, ros::NodeHandle& pnh) :
   pnh.param<int>("decimate_rate", decimate_rate_, 3);
 
   pnh.param<bool>("publish_plane_cloud", publish_plane_cloud_, false);
+  pnh.param<bool>("depth_plane_validation_for_docking", depth_plane_validation_for_docking_, false);
 
   pnh.param<float>("plane_model_distance_threshold", plane_model_distance_threshold_, 0.01f);
 
@@ -297,7 +298,8 @@ void AprilTagDetector::imageCb(const sensor_msgs::PointCloud2ConstPtr& cloud,
       // that check ensures that we only validate depth plane for localization
       // that check means that we skip plane validation for docking (which requires more than 1 april tag detection)
       // full version will not use this hack
-      if (number_of_frames_to_capture_ == 1 && (diffRoll > plane_angle_threshold_) || (diffPitch > plane_angle_threshold_))
+      bool run_plane_validation = depth_plane_validation_for_docking_ || number_of_frames_to_capture_ == 1;
+      if (run_plane_validation && ((diffRoll > plane_angle_threshold_) || (diffPitch > plane_angle_threshold_)))
       {
         ROS_DEBUG_THROTTLE(5.0, "April tag and plane poses do not match!");
         ROS_DEBUG_THROTTLE(5.0, "April angle: %f, %f", aprilTagRoll, aprilTagPitch);


### PR DESCRIPTION
This is a quick and dirty implementation to disable plane validation.
Plane validation is only performed when dock detector only asks for 1 frame in a row to be consistent. Docking requests multiple frames, so doesn't get plane validation.